### PR TITLE
PLAN-1524 Add optional parsers configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ fluent_bit::configs:
     service: 'INPUT'
     name: 'cpu'
     tag: 'tag1'
+
+# optional custom parsers configuration
+fluent_bit::custom_parsers:
+  parser_01:
+    service: 'PARSER'
+    name: 'custom01'
+    format: 'regex'
+    regex: '^(?<time>[^ ]*) (?<message>[^$]*)$'
+    time_key: 'time'
+    time_format: '%Y-%m-%dT%H:%M:%S,%L'
 ```
 
 ## Limitations

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ fluent_bit::configs:
     tag: 'tag1'
 
 # optional custom parsers configuration
-fluent_bit::custom_parsers:
+fluent_bit::parsers:
   parser_01:
     service: 'PARSER'
-    name: 'custom01'
+    name: 'parser_01'
     format: 'regex'
     regex: '^(?<time>[^ ]*) (?<message>[^$]*)$'
     time_key: 'time'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,10 +17,10 @@ class fluent_bit::config inherits fluent_bit {
     notify  => Class['Fluent_bit::Service'],
   }
 
-  if ( $fluent_bit::custom_parsers != {} ) {
-    file { $fluent_bit::custom_parsers_file:
+  if ( $fluent_bit::parsers != {} ) {
+    file { $fluent_bit::parsers_file:
       ensure  => present,
-      content => fluent_bit_config($fluent_bit::custom_parsers),
+      content => fluent_bit_config($fluent_bit::parsers),
       owner   => $fluent_bit::config_owner,
       group   => $fluent_bit::config_group,
       mode    => '0644',
@@ -28,7 +28,7 @@ class fluent_bit::config inherits fluent_bit {
       notify  => Class['Fluent_bit::Service'],
     }
   } else {
-      file { $fluent_bit::custom_parsers_file:
+      file { $fluent_bit::parsers_file:
       ensure => absent,
       notify => Class['Fluent_bit::Service'],
     }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -16,4 +16,22 @@ class fluent_bit::config inherits fluent_bit {
     require => Class['Fluent_bit::Install'],
     notify  => Class['Fluent_bit::Service'],
   }
+
+  if ( $fluent_bit::custom_parsers != {} ) {
+    file { $fluent_bit::custom_parsers_file:
+      ensure  => present,
+      content => fluent_bit_config($fluent_bit::custom_parsers),
+      owner   => $fluent_bit::config_owner,
+      group   => $fluent_bit::config_group,
+      mode    => '0644',
+      require => File[$fluent_bit::config_file],
+      notify  => Class['Fluent_bit::Service'],
+    }
+  } else {
+      file { $fluent_bit::custom_parsers_file:
+      ensure => absent,
+      notify => Class['Fluent_bit::Service'],
+    }
+  }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,8 +22,8 @@ class fluent_bit (
   String $config_owner = $::fluent_bit::params::config_owner,
   String $config_group = $::fluent_bit::params::config_group,
   Hash $configs = $::fluent_bit::params::configs,
-  Optional[String] $custom_parsers_file = $::fluent_bit::params::custom_parsers_file,
-  Optional[Hash] $custom_parsers = $::fluent_bit::params::custom_parsers,
+  Optional[String] $parsers_file = $::fluent_bit::params::parsers_file,
+  Optional[Hash] $parsers = $::fluent_bit::params::parsers,
 ) inherits fluent_bit::params {
   contain fluent_bit::install
   contain fluent_bit::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,8 @@ class fluent_bit (
   String $config_owner = $::fluent_bit::params::config_owner,
   String $config_group = $::fluent_bit::params::config_group,
   Hash $configs = $::fluent_bit::params::configs,
+  Optional[String] $custom_parsers_file = $::fluent_bit::params::custom_parsers_file,
+  Optional[Hash] $custom_parsers = $::fluent_bit::params::custom_parsers,
 ) inherits fluent_bit::params {
   contain fluent_bit::install
   contain fluent_bit::config

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -38,6 +38,6 @@ class fluent_bit::params {
   $config_group = 'root'
   $configs = {}
 
-  $custom_parsers_file = '/etc/td-agent-bit/custom-parsers.conf'
-  $custom_parsers = {}
+  $parsers_file = '/etc/td-agent-bit/parsers-smx.conf'
+  $parsers = {}
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,4 +37,7 @@ class fluent_bit::params {
   $config_owner = 'root'
   $config_group = 'root'
   $configs = {}
+
+  $custom_parsers_file = '/etc/td-agent-bit/custom-parsers.conf'
+  $custom_parsers = {}
 }


### PR DESCRIPTION
td-agent-bit package has got set of standard parsers in parsers.conf file. When we need to use some other custom parsers, they need to be configured in a separate file, path to the file specified via `parsers_file` parameter in the main config.